### PR TITLE
add support for absolute file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+nanobanana-output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 1.0.1
+
+- Fix `edit_file` tool to handle absolute file paths.
+
+## 1.0.0
+
+- Initial release.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nanobanana",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Gemini CLI extension for Nano Banana (Gemini 2.5 Flash Image) model - generate and manipulate images with text prompts",
   "mcpServers": {
     "nanobanana": {

--- a/mcp-server/src/fileHandler.ts
+++ b/mcp-server/src/fileHandler.ts
@@ -30,6 +30,14 @@ export class FileHandler {
   }
 
   static findInputFile(filename: string): FileSearchResult {
+    if (path.isAbsolute(filename) && fs.existsSync(filename)) {
+      return {
+        found: true,
+        filePath: filename,
+        searchedPaths: [],
+      };
+    }
+
     const searchPaths = this.SEARCH_PATHS;
 
     for (const searchPath of searchPaths) {


### PR DESCRIPTION
Also adds a gitignore and changelog.md, and bumps the version to `1.0.1`.

I don't know how releases are handled for this package, but it probably is worth doing one as without this the edit tool consistently fails for me.