### PR TITLE
feat: ship support for Nano Banana Pro 🍌 🍌 🍌 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
+> [!NOTE]  
+> Nano Banana Pro (`gemini-3-pro-image-preview`) is now supported in this extension (v1.0.10+)!
+>
+> Set the `NANOBANANA_MODEL` environment variable to `gemini-3-pro-image-preview` to use it.
+
 # Nano Banana - Gemini CLI Extension
 
-A professional Gemini CLI extension for generating and manipulating images using the **Gemini 2.5 Flash Image** model (Nano Banana).
+A professional Gemini CLI extension for generating and manipulating images using the Nano Banana models.
 
 ## ✨ Features
 
@@ -29,6 +34,21 @@ For authentication setup, see the [official Gemini CLI documentation](https://gi
 - **`imageGenerator.ts`**: Handles all Gemini API interactions and response processing
 - **`fileHandler.ts`**: Manages file I/O, smart filename generation, and file searching
 - **`types.ts`**: Shared TypeScript interfaces for type safety
+
+## 🍌 Model Selection
+
+There are two different Nano Banana models supported by this extension:
+
+- `gemini-2.5-flash-image` (default)
+- `gemini-3-pro-image-preview` (Nano Banana Pro)
+
+The `gemini-2.5-flash-image` model is the default model.
+
+To use the new Gemini 3 Pro powered model set the `NANOBANANA_MODEL` environment variable to `gemini-3-pro-image-preview`.
+
+```bash
+export NANOBANANA_MODEL=gemini-3-pro-image-preview
+```
 
 ## 🚀 Installation
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "nanobanana",
-  "version": "1.0.9",
-  "description": "Gemini CLI extension for Nano Banana (Gemini 2.5 Flash Image) model - generate and manipulate images with text prompts",
+  "version": "1.0.10",
+  "description": "Gemini CLI extension for Nano Banana models - generate and manipulate images with text prompts",
   "mcpServers": {
     "nanobanana": {
       "command": "node",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nanobanana-mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanobanana-mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "dependencies": {
         "@google/genai": "^1.17.0",
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nanobanana-mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.10",
   "type": "module",
-  "description": "MCP server for Nano Banana (Gemini 2.5 Flash Image) extension",
+  "description": "MCP server for Nano Banana extension",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/mcp-server/src/imageGenerator.ts
+++ b/mcp-server/src/imageGenerator.ts
@@ -19,12 +19,16 @@ const execAsync = promisify(exec);
 
 export class ImageGenerator {
   private ai: GoogleGenAI;
-  private static readonly MODEL_NAME = 'gemini-2.5-flash-image';
+  private modelName: string;
+  private static readonly DEFAULT_MODEL = 'gemini-2.5-flash-image';
 
   constructor(authConfig: AuthConfig) {
     this.ai = new GoogleGenAI({
       apiKey: authConfig.apiKey,
     });
+    this.modelName =
+      process.env.NANOBANANA_MODEL || ImageGenerator.DEFAULT_MODEL;
+    console.error(`DEBUG - Using image model: ${this.modelName}`);
   }
 
   private async openImagePreview(filePath: string): Promise<void> {
@@ -254,7 +258,7 @@ export class ImageGenerator {
         try {
           // Make API call for each variation
           const response = await this.ai.models.generateContent({
-            model: ImageGenerator.MODEL_NAME,
+            model: this.modelName,
             contents: [
               {
                 role: 'user',
@@ -440,7 +444,7 @@ export class ImageGenerator {
   
           try {
             const response = await this.ai.models.generateContent({
-              model: ImageGenerator.MODEL_NAME,
+              model: this.modelName,
               contents: [
                 {
                   role: 'user',
@@ -563,7 +567,7 @@ export class ImageGenerator {
       );
 
       const response = await this.ai.models.generateContent({
-        model: ImageGenerator.MODEL_NAME,
+        model: this.modelName,
         contents: [
           {
             role: 'user',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "nanobanana-extension",
-  "version": "1.0.0",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanobanana-extension",
-      "version": "1.0.0",
+      "version": "1.0.10",
+      "hasInstallScript": true,
       "devDependencies": {
         "@types/node": "^22.0.0",
         "eslint": "^9.24.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nanobanana-extension",
-  "version": "1.0.0",
+  "version": "1.0.10",
   "type": "module",
-  "description": "Gemini CLI extension for Nano Banana (Gemini 2.5 Flash Image) model",
+  "description": "Gemini CLI extension for Nano Banana models",
   "scripts": {
     "build": "cd mcp-server && npm run build",
     "install-deps": "cd mcp-server && npm install",


### PR DESCRIPTION
Ship support for [Nano Banana Pro](https://blog.google/technology/ai/nano-banana-pro/). 🍌 

The latest version of Nano Banana, powered by Gemini 3.

Set the `NANOBANANA_MODEL` environment variable to `gemini-3-pro-image-preview` to use it.

```bash
export NANOBANANA_MODEL=gemini-3-pro-image-preview
```

Play around and begin to see the incredible differences in the new model.


## Example

Prompt:

```bash
generate me an image of an infographic explaining how the golden gate bridge works from an engineering point of view 
```

### Nano Banana Pro 🍌
<img width="1408" height="768" alt="image" src="https://github.com/user-attachments/assets/73e6667f-6516-4181-ba1c-11845a5efc06" />

### Nano Banana (2.5 Flash Image)
<img width="500" height="1024" alt="image" src="https://github.com/user-attachments/assets/07c9e35a-b26e-428a-9d69-7602b26caebc" />

Excited to see what you build! 
