### PR TITLE
feat: add aspect ratio support

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -19,6 +19,7 @@ Always respect user-specified design preferences:
 
 - **`--styles`**: Apply the exact artistic styles requested (watercolor, oil-painting, sketch, photorealistic, etc.)
 - **`--variations`**: Implement the specific variation types (lighting, angle, color-palette, composition, mood, season, time-of-day)
+- **`--aspect-ratio`**: Strictly adhere to the requested aspect ratio (1:1, 3:4, 4:3, 9:16, 16:9, 21:9, 3:2, 2:3, 5:4, 4:5).
 - Maintain the essence of the original prompt while applying the requested stylistic changes
 - When multiple styles are requested, ensure each image distinctly represents its assigned style
 

--- a/commands/generate.toml
+++ b/commands/generate.toml
@@ -6,6 +6,7 @@ Valid options:
 - --count=N (1-8, default: 1)
 - --styles="style1,style2" (photorealistic, watercolor, oil-painting, sketch, pixel-art, anime, vintage, modern, abstract, minimalist)
 - --variations="var1,var2" (lighting, angle, color-palette, composition, mood, season, time-of-day)
+- --aspect-ratio="16:9" (1:1, 3:4, 4:3, 9:16, 16:9, 21:9, 3:2, 2:3, 5:4, 4:5)
 - --format=grid|separate (default: separate)
 - --seed=123 (integer)
 - --preview (flag)
@@ -19,7 +20,7 @@ Parse this input and:
 4. If valid, call the generate_image tool with the parsed parameters
 
 If you find invalid options, respond with:
-"Error: Invalid option(s) found: [list invalid options]. Valid options are: --count (1-8), --styles (comma-separated list from: photorealistic, watercolor, oil-painting, sketch, pixel-art, anime, vintage, modern, abstract, minimalist), --variations (comma-separated list from: lighting, angle, color-palette, composition, mood, season, time-of-day), --format (grid or separate), --seed (integer), --preview (flag)"
+"Error: Invalid option(s) found: [list invalid options]. Valid options are: --count (1-8), --styles (comma-separated list from: photorealistic, watercolor, oil-painting, sketch, pixel-art, anime, vintage, modern, abstract, minimalist), --variations (comma-separated list from: lighting, angle, color-palette, composition, mood, season, time-of-day), --aspect-ratio (1:1, 3:4, 4:3, 9:16, 16:9, 21:9, 3:2, 2:3, 5:4, 4:5), --format (grid or separate), --seed (integer), --preview (flag)"
 
 Otherwise, call generate_image with the validated parameters.
 """

--- a/commands/story.toml
+++ b/commands/story.toml
@@ -6,6 +6,7 @@ Valid options:
 - --steps=N (2-8, default: 4)
 - --type="story|process|tutorial|timeline" (default: story)
 - --style="consistent|evolving" (default: consistent)
+- --aspect-ratio="16:9" (1:1, 3:4, 4:3, 9:16, 16:9, 21:9, 3:2, 2:3, 5:4, 4:5)
 - --layout="separate|grid|comic" (default: separate)
 - --transition="smooth|dramatic|fade" (default: smooth)
 - --format="storyboard|individual" (default: individual)
@@ -21,7 +22,7 @@ Parse this input and:
 5. If valid, call the generate_story tool with the parsed parameters
 
 If you find invalid options, respond with:
-"Error: Invalid option(s) found: [list invalid options]. Valid options are: --steps (2-8), --type (story, process, tutorial, timeline), --style (consistent, evolving), --layout (separate, grid, comic), --transition (smooth, dramatic, fade), --format (storyboard, individual), --preview (flag)"
+"Error: Invalid option(s) found: [list invalid options]. Valid options are: --steps (2-8), --type (story, process, tutorial, timeline), --style (consistent, evolving), --aspect-ratio (1:1, 3:4, 4:3, 9:16, 16:9, 21:9, 3:2, 2:3, 5:4, 4:5), --layout (separate, grid, comic), --transition (smooth, dramatic, fade), --format (storyboard, individual), --preview (flag)"
 
 Otherwise, call generate_story with the validated parameters.
 """

--- a/mcp-server/src/imageGenerator.ts
+++ b/mcp-server/src/imageGenerator.ts
@@ -237,10 +237,37 @@ export class ImageGenerator {
     return prompts.length > 0 ? prompts : [basePrompt];
   }
 
+  private validateAspectRatio(ratio: string): void {
+    const validRatios = [
+      '1:1',
+      '3:4',
+      '4:3',
+      '9:16',
+      '16:9',
+      '21:9',
+      '3:2',
+      '2:3',
+      '5:4',
+      '4:5',
+    ];
+
+    if (!validRatios.includes(ratio)) {
+      throw new Error(
+        `Aspect ratio '${ratio}' is not supported. Supported ratios are: ${validRatios.join(
+          ', ',
+        )}`,
+      );
+    }
+  }
+
   async generateTextToImage(
     request: ImageGenerationRequest,
   ): Promise<ImageGenerationResponse> {
     try {
+      if (request.aspectRatio) {
+        this.validateAspectRatio(request.aspectRatio);
+      }
+
       const outputPath = FileHandler.ensureOutputDirectory();
       const generatedFiles: string[] = [];
       const prompts = this.buildBatchPrompts(request);
@@ -265,6 +292,11 @@ export class ImageGenerator {
                 parts: [{ text: currentPrompt }],
               },
             ],
+            config: {
+              imageConfig: request.aspectRatio
+                ? { aspectRatio: request.aspectRatio }
+                : undefined,
+            } as any,
           });
 
           console.error('DEBUG - API Response structure for variation', i + 1);
@@ -404,6 +436,10 @@ export class ImageGenerator {
       args?: StorySequenceArgs,
     ): Promise<ImageGenerationResponse> {
       try {
+        if (request.aspectRatio) {
+          this.validateAspectRatio(request.aspectRatio);
+        }
+
         const outputPath = FileHandler.ensureOutputDirectory();
         const generatedFiles: string[] = [];
         const steps = request.outputCount || 4;
@@ -451,6 +487,11 @@ export class ImageGenerator {
                   parts: [{ text: stepPrompt }],
                 },
               ],
+              config: {
+                imageConfig: request.aspectRatio
+                  ? { aspectRatio: request.aspectRatio }
+                  : undefined,
+              } as any,
             });
   
             if (response.candidates && response.candidates[0]?.content?.parts) {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -86,6 +86,11 @@ class NanoBananaServer {
                   description:
                     'Array of variation types: lighting, angle, color-palette, composition, mood, season, time-of-day',
                 },
+                aspectRatio: {
+                  type: 'string',
+                  description:
+                    'Aspect ratio of the generated image (e.g., "1:1", "3:4", "4:3", "9:16", "16:9")',
+                },
                 format: {
                   type: 'string',
                   enum: ['grid', 'separate'],
@@ -320,6 +325,11 @@ class NanoBananaServer {
                   description: 'Output format',
                   default: 'individual',
                 },
+                aspectRatio: {
+                  type: 'string',
+                  description:
+                    'Aspect ratio of the generated image (e.g., "1:1", "3:4", "4:3", "9:16", "16:9")',
+                },
                 preview: {
                   type: 'boolean',
                   description:
@@ -418,6 +428,7 @@ class NanoBananaServer {
               mode: 'generate',
               styles: args?.styles as string[],
               variations: args?.variations as string[],
+              aspectRatio: args?.aspectRatio as string,
               format: (args?.format as 'grid' | 'separate') || 'separate',
               seed: args?.seed as number,
               preview: args?.preview as boolean,
@@ -495,6 +506,7 @@ class NanoBananaServer {
               outputCount: (args?.steps as number) || 4,
               mode: 'generate',
               variations: ['sequence-step'],
+              aspectRatio: args?.aspectRatio as string,
               preview: args?.preview as boolean,
               noPreview:
                 (args?.noPreview as boolean) ||

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -12,6 +12,7 @@ export interface ImageGenerationRequest {
   // Batch generation options
   styles?: string[];
   variations?: string[];
+  aspectRatio?: string;
   format?: 'grid' | 'separate';
   fileFormat?: 'png' | 'jpeg';
   seed?: number;


### PR DESCRIPTION
This PR adds support for specifying aspect ratios when generating images and stories. Users can now use the `--aspect-ratio` flag with values like `16:9`, `4:3`, `1:1`, etc.

## Implementation Details
- **`any` Casting in `imageGenerator.ts`:**
  The Google GenAI Node.js SDK's current type definitions for `generateContent` configuration (`GenerationConfig`) do not yet include the `imageConfig` property used by the image generation models. To bypass this type check while ensuring the parameter is correctly passed to the API (which supports it), I've cast the config object to `any`. Not ideal, but allows us to leverage the feature immediately without waiting for SDK type updates.

- **Validation:**
  Added a validation step to ensure only supported aspect ratios are passed to the API.

## Usage
You can now control the dimensions of your generated images using the `--aspect-ratio` flag.

### Generate Command
```bash
# Cinematic widescreen
/generate "A cyberpunk city" --aspect-ratio="21:9"

# Portrait for mobile
/generate "A fashion model" --aspect-ratio="9:16"
```

### Story Command
The aspect ratio applies to all frames in the story sequence.
```bash
/story "A space opera" --steps=4 --aspect-ratio="16:9"
```

### Supported Ratios
- `1:1` (Square)
- `3:4`, `4:3`
- `9:16`, `16:9`
- `21:9` (Ultrawide)
- `3:2`, `2:3`
- `5:4`, `4:5`