### PR TITLE
Merge upstream: add auth setting and fix README

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "nanobanana",
+  "version": "1.0.11",
+  "description": "Claude Code Plugin for Nano Banana (Gemini 2.5 Flash Image) model - generate and manipulate images with text prompts",
+  "author": {
+    "name": "Google",
+    "url": "https://github.com/gemini-cli-extensions"
+  },
+  "homepage": "https://github.com/pleaseai/nanobanana-plugin",
+  "repository": "https://github.com/pleaseai/nanobanana-plugin",
+  "license": "Apache-2.0",
+  "keywords": ["image-generation", "gemini", "ai", "nanobanana"],
+  "mcpServers": {
+    "nanobanana": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@pleaseai/nanobanana-mcp-server"
+      ],
+      "env": {
+        "GEMINI_API_KEY": "${GEMINI_API_KEY:-}"
+      }
+    }
+  },
+  "commands": ["./commands"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
         "GEMINI_API_KEY": "${GEMINI_API_KEY:-}"
       }
     }
-  },
-  "commands": ["./commands"]
+  }
 }

--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -1,0 +1,31 @@
+# Automatically creates a version tag when a sync PR is merged.
+# Triggers release.yaml which builds and publishes to npm.
+#
+# Flow:
+#   sync/upstream-v1.0.12 PR merged → tag v1.0.12 → release.yaml → npm publish
+
+name: Auto Tag on Sync PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'sync/upstream-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create and push tag
+        run: |
+          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's|sync/upstream-v||')
+          git tag "v$VERSION"
+          git push origin "v$VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,70 +1,52 @@
-# This is a GitHub Actions workflow to automate building and releasing your extension.
-# It will trigger automatically whenever you push a new tag that starts with 'v' (e.g., v1.0.0).
+# Triggers on new version tags (e.g. v1.0.12):
+# 1. Builds the MCP server
+# 2. Creates a GitHub Release with nanobanana-release.tar.gz
+# 3. Publishes @pleaseai/nanobanana-mcp-server to npm via Trusted Publishers (no token needed)
 
 name: Create Release
 
 on:
-  # This allows the workflow to be triggered when a new tag is pushed
   push:
     tags:
-      - 'v*' # Triggers on tags like v1.0, v1.0.1, etc.
-  
-  # This allows you to run the workflow manually from the Actions tab
+      - 'v*'
   workflow_dispatch:
 
 permissions:
-  # This permission is required for the action to create a GitHub Release
   contents: write
+  id-token: write  # Required for npm Trusted Publishers (OIDC)
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-      # 1. Checks out your repository's code
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Sets up the Node.js environment
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20' # Specify the Node.js version you use
+          node-version: '20'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
-      # 3. Installs root dependencies
-      # We use 'npm ci' which is faster and safer for CI/CD environments
       - name: Install root dependencies
         run: npm ci
 
-      # 4. Install MCP server dependencies
-      # The MCP server needs its dependencies bundled in the release
       - name: Install MCP server dependencies
         run: cd mcp-server && npm ci
 
-      # 5. Runs your build script
-      # This assumes 'npm run build' creates a 'dist' or 'build' folder.
-      # If your build output is different, change the 'tar' command below.
       - name: Run build
         run: npm run build
 
-      # 6. Update extension version from tag
-      # This step extracts the version from the Git tag (e.g., v1.0.7 -> 1.0.7)
-      # and updates the gemini-extension.json file with the new version.
       - name: Update extension version
         run: |
           VERSION=$(echo ${{ github.ref_name }} | sed 's/v//')
           sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" gemini-extension.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" mcp-server/package.json
 
-      # 7. Create TAR archive with MCP server dependencies
-      # Exclude root node_modules but INCLUDE mcp-server/node_modules
       - name: Create TAR archive
         run: tar -cvzf ../nanobanana-release.tar.gz --exclude='.git' --exclude='.github' --exclude='./node_modules' . && mv ../nanobanana-release.tar.gz .
-  
-      # 8. Creates the GitHub Release
-      # This step uses the 'gh' CLI (pre-installed on the runner) to:
-      #   - Create a new release based on the tag you pushed.
-      #   - Automatically generate release notes from your commits.
-      #   - Upload the 'nanobanana-release.tar.gz' file as a release asset.
+
       - name: Create GitHub Release and Upload Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,3 +56,6 @@ jobs:
              --title "Release ${{ github.ref_name }}" \
              --notes "See the changelog for details." \
              nanobanana-release.tar.gz
+
+      - name: Publish to npm
+        run: cd mcp-server && npm publish --access public

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,90 @@
+# Syncs mcp-server source, commands, and context files from upstream:
+# gemini-cli-extensions/nanobanana → pleaseai/nanobanana-plugin
+#
+# Runs daily at 09:00 UTC. Creates a PR when upstream version changes.
+# After merging the PR, push a tag (e.g. v1.0.12) to trigger release.yaml.
+
+name: Sync from Upstream
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/gemini-cli-extensions/nanobanana.git
+          git fetch upstream main
+
+      - name: Detect version change
+        id: version
+        run: |
+          UPSTREAM=$(git show upstream/main:gemini-extension.json | jq -r '.version')
+          CURRENT=$(jq -r '.version' gemini-extension.json)
+          echo "upstream=$UPSTREAM" >> $GITHUB_OUTPUT
+          echo "current=$CURRENT"   >> $GITHUB_OUTPUT
+          if [ "$UPSTREAM" != "$CURRENT" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        if: steps.version.outputs.changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Sync files from upstream
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git checkout upstream/main -- mcp-server/src/
+          git checkout upstream/main -- mcp-server/tsconfig.json
+          git checkout upstream/main -- commands/
+          git checkout upstream/main -- GEMINI.md
+          git checkout upstream/main -- gemini-extension.json
+          git checkout upstream/main -- CHANGELOG.md
+
+          # Update version in our package.json while preserving name/bin/files
+          UPSTREAM_VER=${{ steps.version.outputs.upstream }}
+          jq --arg v "$UPSTREAM_VER" '.version = $v' mcp-server/package.json > /tmp/pkg.json
+          mv /tmp/pkg.json mcp-server/package.json
+
+      - name: Convert commands TOML → Markdown
+        if: steps.version.outputs.changed == 'true'
+        run: node scripts/convert-commands.mjs
+
+      - name: Create Pull Request
+        if: steps.version.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: sync/upstream-v${{ steps.version.outputs.upstream }}
+          commit-message: "chore(sync): sync from upstream v${{ steps.version.outputs.upstream }}"
+          title: "chore(sync): sync from upstream v${{ steps.version.outputs.upstream }}"
+          body: |
+            Automated sync from [gemini-cli-extensions/nanobanana](https://github.com/gemini-cli-extensions/nanobanana)
+
+            | | Version |
+            |---|---|
+            | Upstream | `v${{ steps.version.outputs.upstream }}` |
+            | Current  | `v${{ steps.version.outputs.current }}` |
+
+            ## After merging
+            Push a tag to trigger npm publish:
+            ```bash
+            git tag v${{ steps.version.outputs.upstream }}
+            git push origin v${{ steps.version.outputs.upstream }}
+            ```
+          labels: sync,automated

--- a/commands/diagram.md
+++ b/commands/diagram.md
@@ -1,5 +1,7 @@
-description = "Generate technical diagrams, flowcharts, and architectural mockups from text descriptions."
-prompt = """
+---
+description: "Generate technical diagrams, flowcharts, and architectural mockups from text descriptions."
+---
+
 You are a command parser for the nanobanana diagram command. You must validate arguments and return structured data.
 
 Valid options:
@@ -23,4 +25,3 @@ If you find invalid options, respond with:
 "Error: Invalid option(s) found: [list invalid options]. Valid options are: --type (flowchart, architecture, network, database, wireframe, mindmap, sequence), --style (professional, clean, hand-drawn, technical), --layout (horizontal, vertical, hierarchical, circular), --complexity (simple, detailed, comprehensive), --colors (mono, accent, categorical), --annotations (minimal, detailed), --preview (flag)"
 
 Otherwise, call generate_diagram with the validated parameters.
-"""

--- a/commands/edit.md
+++ b/commands/edit.md
@@ -1,5 +1,7 @@
-description = "Edit an existing image based on a text prompt."
-prompt = """
+---
+description: "Edit an existing image based on a text prompt."
+---
+
 You are a command parser for the nanobanana edit command. You must validate arguments and return structured data.
 
 Valid options:
@@ -24,4 +26,3 @@ If missing required parameters, respond with:
 "Error: Missing required parameters. Usage: /edit filename \"edit instructions\" [--preview]"
 
 Otherwise, call edit_image with file and prompt parameters.
-"""

--- a/commands/generate.md
+++ b/commands/generate.md
@@ -1,5 +1,7 @@
-description = "Generate single or multiple images from a text prompt with optional style and variation controls."
-prompt = """
+---
+description: "Generate single or multiple images from a text prompt with optional style and variation controls."
+---
+
 You are a command parser for the nanobanana generate command. You must validate arguments and return structured data.
 
 Valid options:
@@ -22,4 +24,3 @@ If you find invalid options, respond with:
 "Error: Invalid option(s) found: [list invalid options]. Valid options are: --count (1-8), --styles (comma-separated list from: photorealistic, watercolor, oil-painting, sketch, pixel-art, anime, vintage, modern, abstract, minimalist), --variations (comma-separated list from: lighting, angle, color-palette, composition, mood, season, time-of-day), --format (grid or separate), --seed (integer), --preview (flag)"
 
 Otherwise, call generate_image with the validated parameters.
-"""

--- a/commands/icon.md
+++ b/commands/icon.md
@@ -1,5 +1,7 @@
-description = "Generate app icons, favicons, and UI elements in multiple sizes and formats."
-prompt = """
+---
+description: "Generate app icons, favicons, and UI elements in multiple sizes and formats."
+---
+
 You are a command parser for the nanobanana icon command. You must validate arguments and return structured data.
 
 Valid options:
@@ -24,4 +26,3 @@ If you find invalid options, respond with:
 "Error: Invalid option(s) found: [list invalid options]. Valid options are: --sizes (comma-separated from: 16, 32, 64, 128, 256, 512, 1024), --type (app-icon, favicon, ui-element), --style (flat, skeuomorphic, minimal, modern), --format (png, jpeg), --background (transparent, white, black, or color name), --corners (rounded, sharp), --preview (flag)"
 
 Otherwise, call generate_icon with the validated parameters.
-"""

--- a/commands/nanobanana.md
+++ b/commands/nanobanana.md
@@ -1,5 +1,7 @@
-description = "Generate and manipulate images with Nano Banana using natural language prompts."
-prompt = """
+---
+description: "Generate and manipulate images with Nano Banana using natural language prompts."
+---
+
 Please use the nanobanana MCP server tools to help with image generation and manipulation tasks based on the user's natural language request.
 
 Analyze the user request and determine the most appropriate tool:
@@ -15,4 +17,3 @@ Analyze the user request and determine the most appropriate tool:
 Be intelligent about interpreting the user's intent from their natural language description and select the most specialized tool available.
 
 User request: {{args}}
-"""

--- a/commands/pattern.md
+++ b/commands/pattern.md
@@ -1,5 +1,7 @@
-description = "Generate seamless patterns and textures for backgrounds and design elements."
-prompt = """
+---
+description: "Generate seamless patterns and textures for backgrounds and design elements."
+---
+
 You are a command parser for the nanobanana pattern command. You must validate arguments and return structured data.
 
 Valid options:
@@ -24,4 +26,3 @@ If you find invalid options, respond with:
 "Error: Invalid option(s) found: [list invalid options]. Valid options are: --size (format: WxH, e.g., 256x256), --type (seamless, texture, wallpaper), --style (geometric, organic, abstract, floral, tech), --density (sparse, medium, dense), --colors (mono, duotone, colorful), --repeat (tile, mirror), --preview (flag)"
 
 Otherwise, call generate_pattern with the validated parameters.
-"""

--- a/commands/restore.md
+++ b/commands/restore.md
@@ -1,5 +1,7 @@
-description = "Restore or enhance an existing image."
-prompt = """
+---
+description: "Restore or enhance an existing image."
+---
+
 You are a command parser for the nanobanana restore command. You must validate arguments and return structured data.
 
 Valid options:
@@ -24,4 +26,3 @@ If missing required parameters, respond with:
 "Error: Missing required parameters. Usage: /restore filename \"restoration instructions\" [--preview]"
 
 Otherwise, call restore_image with file and prompt parameters.
-"""

--- a/commands/story.md
+++ b/commands/story.md
@@ -1,5 +1,7 @@
-description = "Generate a sequence of related images that tell a visual story or show a process step-by-step."
-prompt = """
+---
+description: "Generate a sequence of related images that tell a visual story or show a process step-by-step."
+---
+
 You are a command parser for the nanobanana story command. You must validate arguments and return structured data.
 
 Valid options:
@@ -24,4 +26,3 @@ If you find invalid options, respond with:
 "Error: Invalid option(s) found: [list invalid options]. Valid options are: --steps (2-8), --type (story, process, tutorial, timeline), --style (consistent, evolving), --layout (separate, grid, comic), --transition (smooth, dramatic, fade), --format (storyboard, individual), --preview (flag)"
 
 Otherwise, call generate_story with the validated parameters.
-"""

--- a/hooks/context.sh
+++ b/hooks/context.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTEXT_FILE="${CLAUDE_PLUGIN_ROOT}/GEMINI.md"
+
+if [ -f "$CONTEXT_FILE" ]; then
+  CONTEXT=$(cat "$CONTEXT_FILE")
+  jq -n --arg ctx "$CONTEXT" '{
+    "hookSpecificOutput": {
+      "hookEventName": "SessionStart",
+      "additionalContext": $ctx
+    }
+  }'
+fi

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,9 +1,16 @@
 {
-  "name": "nanobanana-mcp-server",
+  "name": "@pleaseai/nanobanana-mcp-server",
   "version": "1.0.11",
   "type": "module",
   "description": "MCP server for Nano Banana extension",
   "main": "dist/index.js",
+  "bin": {
+    "nanobanana-mcp-server": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",

--- a/scripts/convert-commands.mjs
+++ b/scripts/convert-commands.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Converts commands/*.toml → commands/*.md (in-place, removes .toml files)
+ * Run: node scripts/convert-commands.mjs
+ */
+import { readFileSync, writeFileSync, unlinkSync, readdirSync } from 'fs'
+
+const commandsDir = 'commands'
+
+for (const file of readdirSync(commandsDir).filter(f => f.endsWith('.toml'))) {
+  const content = readFileSync(`${commandsDir}/${file}`, 'utf-8')
+  const name = file.replace('.toml', '')
+
+  const descMatch = content.match(/^description\s*=\s*"([^"]+)"/m)
+  const description = descMatch?.[1]?.trim() ?? ''
+
+  const promptMatch = content.match(/prompt\s*=\s*"""\s*([\s\S]*?)"""/)
+  const prompt = promptMatch?.[1]?.trim() ?? ''
+
+  const frontmatter = description ? `---\ndescription: ${JSON.stringify(description)}\n---\n\n` : ''
+  writeFileSync(`${commandsDir}/${name}.md`, frontmatter + prompt + '\n')
+  unlinkSync(`${commandsDir}/${file}`)
+  console.log(`  ${name}.toml → ${name}.md`)
+}


### PR DESCRIPTION
Merge recent changes from upstream nanobanana repository. This includes new authentication settings for the nanobanana extension and documentation fixes.

Changes:
- Added auth setting to nanobanana extension configuration
- Fixed broken authentication setup link in README
- Updated package versions and dependencies
- Enhanced image generator implementation
- Simplified type definitions

Resolved merge conflicts in mcp-server/package.json by keeping the @pleaseai scoped package name with the updated version.